### PR TITLE
Detect arrays from Lua and convert them to Go arrays.

### DIFF
--- a/goluago.go
+++ b/goluago.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Shopify/goluago/pkg/regexp"
 	"github.com/Shopify/goluago/pkg/strings"
 	"github.com/Shopify/goluago/pkg/time"
+	"github.com/Shopify/goluago/util"
 )
 
 func Open(l *lua.State) {
@@ -17,4 +18,5 @@ func Open(l *lua.State) {
 	time.Open(l)
 	fmt.Open(l)
 	url.Open(l)
+	util.Open(l)
 }

--- a/util/deep_pull.go
+++ b/util/deep_pull.go
@@ -3,8 +3,13 @@ package util
 import (
 	"errors"
 	"fmt"
+
 	"github.com/Shopify/go-lua"
 )
+
+func Open(l *lua.State) {
+	lua.Register(l, "array", luaArray)
+}
 
 func PullStringTable(l *lua.State, idx int) (map[string]string, error) {
 	if !lua.IsTable(l, idx) {
@@ -34,7 +39,7 @@ func PullStringTable(l *lua.State, idx int) (map[string]string, error) {
 	return table, nil
 }
 
-func PullTable(l *lua.State, idx int) (map[string]interface{}, error) {
+func PullTable(l *lua.State, idx int) (interface{}, error) {
 	if !lua.IsTable(l, idx) {
 		return nil, fmt.Errorf("need a table at index %d, got %s", idx, lua.TypeNameOf(l, idx))
 	}
@@ -42,12 +47,16 @@ func PullTable(l *lua.State, idx int) (map[string]interface{}, error) {
 	return pullTableRec(l, idx)
 }
 
-func pullTableRec(l *lua.State, idx int) (map[string]interface{}, error) {
+func pullTableRec(l *lua.State, idx int) (interface{}, error) {
 	if !lua.CheckStack(l, 2) {
 		return nil, errors.New("pull table, stack exhausted")
 	}
 
 	idx = lua.AbsIndex(l, idx)
+	if isArray(l, idx) {
+		return pullArrayRec(l, idx)
+	}
+
 	table := make(map[string]interface{})
 
 	lua.PushNil(l)
@@ -60,27 +69,78 @@ func pullTableRec(l *lua.State, idx int) (map[string]interface{}, error) {
 			return nil, err
 		}
 
-		t := lua.TypeOf(l, -1)
-		switch t {
-		case lua.TypeString:
-			table[key] = lua.CheckString(l, -1)
-		case lua.TypeNumber:
-			table[key] = lua.CheckInteger(l, -1)
-		case lua.TypeTable:
-			val, err := pullTableRec(l, -1)
-			if err != nil {
-				lua.Pop(l, 2)
-				return nil, err
-			}
-			table[key] = val
-		default:
-			err := fmt.Errorf("pull table, unsupported type %s", lua.TypeNameOf(l, -1))
+		value, err := toGoValue(l, -1)
+		if err != nil {
 			lua.Pop(l, 2)
 			return nil, err
 		}
+
+		table[key] = value
 
 		lua.Pop(l, 1)
 	}
 
 	return table, nil
+}
+
+const arrayMarkerField = "_is_array"
+
+func luaArray(l *lua.State) int {
+	lua.NewTable(l)
+	lua.PushBoolean(l, true)
+	lua.SetField(l, -2, arrayMarkerField)
+	lua.SetMetaTable(l, -2)
+	return 1
+}
+
+func isArray(l *lua.State, idx int) bool {
+	if !lua.IsTable(l, idx) {
+		return false
+	}
+
+	if !lua.MetaField(l, idx, arrayMarkerField) {
+		return false
+	}
+	defer lua.Pop(l, 1)
+
+	return lua.ToBoolean(l, -1)
+}
+
+func pullArrayRec(l *lua.State, idx int) (interface{}, error) {
+	table := make([]interface{}, lua.LengthEx(l, idx))
+
+	lua.PushNil(l)
+	for lua.Next(l, idx) {
+		k, ok := lua.ToInteger(l, -2)
+		if !ok {
+			lua.Pop(l, 2)
+			return nil, fmt.Errorf("pull array: expected numeric index, got '%s'", lua.TypeOf(l, -2))
+		}
+
+		v, err := toGoValue(l, -1)
+		if err != nil {
+			lua.Pop(l, 2)
+			return nil, err
+		}
+
+		table[k-1] = v
+		lua.Pop(l, 1)
+	}
+
+	return table, nil
+}
+
+func toGoValue(l *lua.State, idx int) (interface{}, error) {
+	t := lua.TypeOf(l, idx)
+	switch t {
+	case lua.TypeString:
+		return lua.CheckString(l, idx), nil
+	case lua.TypeNumber:
+		return lua.CheckInteger(l, idx), nil
+	case lua.TypeTable:
+		return pullTableRec(l, idx)
+	default:
+		err := fmt.Errorf("pull table, unsupported type %s", lua.TypeNameOf(l, idx))
+		return nil, err
+	}
 }


### PR DESCRIPTION
I'm am trying to work around the lack of arrays in Lua. This is a problem when we try to generate JSON and we want an Array and not an object indexed by numbers. My approach relies on detecting continuously increasing integer indices. I'm not sure I like it, another alternative would be to have an `array` function that would set a particular metatable on our array (similar to what Javascript does), then `PullTable` could detect that and generate a `[]interface{}` instead of a `map[string]interface{}`.

r: @fbogsany, @davidcornu 
cc: @volmer 
