### PR TITLE
Added base64 encode/decode and hmac signing with sha256

### DIFF
--- a/goluago.go
+++ b/goluago.go
@@ -2,6 +2,8 @@ package goluago
 
 import (
 	"github.com/Shopify/go-lua"
+	"github.com/Shopify/goluago/pkg/crypto/hmac"
+	"github.com/Shopify/goluago/pkg/encoding/base64"
 	"github.com/Shopify/goluago/pkg/encoding/json"
 	"github.com/Shopify/goluago/pkg/env"
 	"github.com/Shopify/goluago/pkg/fmt"
@@ -20,5 +22,7 @@ func Open(l *lua.State) {
 	fmt.Open(l)
 	url.Open(l)
 	util.Open(l)
+	hmac.Open(l)
+	base64.Open(l)
 	env.Open(l)
 }

--- a/pkg/crypto/hmac/hmac.go
+++ b/pkg/crypto/hmac/hmac.go
@@ -1,0 +1,30 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"github.com/Shopify/go-lua"
+)
+
+func Open(l *lua.State) {
+	hmacOpen := func(l *lua.State) int {
+		lua.NewLibrary(l, hmacLibrary)
+		return 1
+	}
+	lua.Require(l, "goluago/crypto/hmac", hmacOpen, false)
+	lua.Pop(l, 1)
+}
+
+var hmacLibrary = []lua.RegistryFunction{
+	{"signsha256", g},
+}
+
+func g(l *lua.State) int {
+	message := lua.CheckString(l, 1)
+	key := lua.CheckString(l, 2)
+
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	lua.PushString(l, string(mac.Sum(nil)))
+	return 1
+}

--- a/pkg/encoding/base64/base64.go
+++ b/pkg/encoding/base64/base64.go
@@ -1,0 +1,37 @@
+package base64
+
+import (
+	"encoding/base64"
+	"github.com/Shopify/go-lua"
+)
+
+func Open(l *lua.State) {
+	base64Open := func(l *lua.State) int {
+		lua.NewLibrary(l, base64Library)
+		return 1
+	}
+	lua.Require(l, "goluago/encoding/base64", base64Open, false)
+	lua.Pop(l, 1)
+}
+
+var base64Library = []lua.RegistryFunction{
+	{"encode", encode},
+	{"decode", decode},
+}
+
+func encode(l *lua.State) int {
+	data := lua.CheckString(l, 1)
+	lua.PushString(l, base64.StdEncoding.EncodeToString([]byte(data)))
+	return 1
+}
+
+func decode(l *lua.State) int {
+	data := lua.CheckString(l, 1)
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		lua.Errorf(l, err.Error())
+		panic("unreachable")
+	}
+	lua.PushString(l, string(decoded))
+	return 1
+}

--- a/tst/crypto/hmac/hmac_test.lua
+++ b/tst/crypto/hmac/hmac_test.lua
@@ -1,0 +1,6 @@
+local crypto = require("goluago/crypto/hmac")
+
+--signsha256
+equals("compute hmac with sha256", "\40\122\59\216\164\252\119\49\169\76\114\32\121\5\83\35\100\77\135\152\189\41\27\249\135\138\188\155\143\212\177\208", crypto.signsha256("message", "secret-key"))
+equals("compute hmac with sha256 and empty secret", "\235\8\193\245\109\93\222\224\127\123\223\128\70\128\131\218\6\182\76\244\250\198\79\227\169\8\131\223\95\234\202\228", crypto.signsha256("message", ""))
+equals("compute hmac with sha256 and empty message", "\43\144\206\61\144\91\186\34\107\61\1\135\87\7\27\42\131\151\216\228\45\157\61\187\150\156\150\173\132\85\221\186", crypto.signsha256("", "foobar"))

--- a/tst/encoding/base64/base64_test.lua
+++ b/tst/encoding/base64/base64_test.lua
@@ -1,0 +1,9 @@
+local base64 = require("goluago/encoding/base64")
+
+--encode
+equals("an empty string outputs nothing", "", base64.encode(""))
+equals("encodes a string to base64", "Zm9vYmFy", base64.encode("foobar"))
+
+--decode
+equals("an empty string outputs nothing", "", base64.decode(""))
+equals("decodes a base64 encded string", "ZXhhbXBsZS1tZXNzYWdlLWZvb2Jhcg==", base64.encode("example-message-foobar"))

--- a/tst/lua_test.go
+++ b/tst/lua_test.go
@@ -16,6 +16,8 @@ var tests = []struct {
 	{"time", "time/time_test.lua"},
 	{"url", "net/url/url_test.lua"},
 	{"env", "env/env_test.lua"},
+	{"hmac", "crypto/hmac/hmac_test.lua"},
+	{"base64", "encoding/base64/base64_test.lua"},
 }
 
 func TestAllPackages(t *testing.T) {


### PR DESCRIPTION
This PR adds hmac signing with sha256 hashes and base64 encoding/decoding.

Edit: Might be missing some context. I'd like to test an endpoint we hit with webhooks, but need to sign them with hmac+sha256 and base64 encode it.

@fbogsany 

cc @sgnr 
