### PR TITLE
Replaces repository hosted on code.google.com

### DIFF
--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,7 +1,7 @@
 package uuid
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"github.com/Shopify/go-lua"
 )
 


### PR DESCRIPTION
Since code.google.com shut down, [code.google.com/p/go-uuid/uuid](code.google.com/p/go-uuid/uuid) has moved to [https://github.com/pborman/uuid](https://github.com/pborman/uuid). 

With more recent versions of go, `go get github.com/Shopify/goluago` will fail with the error:

```
package code.google.com/p/go-uuid/uuid: unable to detect version control system for code.google.com/ path
```