### PR TITLE
Add url escape/unescape

### DIFF
--- a/pkg/net/url/url.go
+++ b/pkg/net/url/url.go
@@ -19,6 +19,8 @@ func Open(l *lua.State) {
 
 var urlLibrary = []lua.RegistryFunction{
 	{"parse", parse},
+	{"escape", escape},
+	{"unescape", unescape},
 }
 
 func parse(l *lua.State) int {
@@ -133,4 +135,25 @@ func urlString(u *url.URL) lua.Function {
 		l.PushString(u.String())
 		return 1
 	}
+}
+
+func escape(l *lua.State) int {
+	query := lua.CheckString(l, 1)
+	escapedUrl := url.QueryEscape(query)
+
+	l.PushString(escapedUrl)
+	return 1
+}
+
+func unescape(l *lua.State) int {
+	query := lua.CheckString(l, 1)
+	url, err := url.QueryUnescape(query)
+
+	if err != nil {
+		lua.Errorf(l, err.Error())
+		panic("unreachable")
+	}
+
+	l.PushString(url)
+	return 1
 }

--- a/tst/net/url/url_test.lua
+++ b/tst/net/url/url_test.lua
@@ -12,3 +12,6 @@ u.host = "google.com"
 equals("can change host", "google.com", u.host)
 equals("can change scheme", "https", u.scheme)
 equals("can change string", "https://google.com/search?q=dotnet", u.string())
+
+equals("can escape", "https%3A%2F%2Fa.com%3Fsearch%3Dbob%2B1%40a.com", url.escape("https://a.com?search=bob+1@a.com"))
+equals("can unescape", "https://a.com?search=bob+1@a.com", url.unescape("https%3A%2F%2Fa.com%3Fsearch%3Dbob%2B1%40a.com"))


### PR DESCRIPTION
I needed to escape urls with special characters. To do so I tried implementing something similar to this https://gist.github.com/liukun/f9ce7d6d14fa45fe9b924a3eed5c3d99, but it seemed easier to expose the method from go stdlib.

@sgnr @fbogsany 
/cc @jpcaissy 