### PR TITLE
Mark a table as array when pushing a slice/array

### DIFF
--- a/util/deep_push.go
+++ b/util/deep_push.go
@@ -2,8 +2,9 @@ package util
 
 import (
 	"fmt"
-	"github.com/Shopify/go-lua"
 	"reflect"
+
+	"github.com/Shopify/go-lua"
 )
 
 // DeepPush will put any basic Go type on the lua stack. If the value
@@ -108,6 +109,7 @@ func forwardOnReflect(l *lua.State, val interface{}) {
 // type of slice
 func recurseOnFuncSlice(l *lua.State, input func(int) interface{}, n int) {
 	l.CreateTable(n, 0)
+	luaArray(l)
 	for i := 0; i < n; i++ {
 		forwardOnType(l, input(i))
 		l.RawSetInt(-2, i+1)


### PR DESCRIPTION
`DeepPush` creates a Lua table when it encounters a slice or array. The table is not marked as an array, however, so a `DeepPull` of the table subsequently fails. This fixes the failure by marking the new table as an array.