### PR TITLE
converted nano unix time while computing the format

### DIFF
--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -32,7 +32,7 @@ func format(l *lua.State) int {
 		lua.Errorf(l, err.Error())
 	}
 
-	unixTime := time.Unix(0, epochNanoToFormat)
+	unixTime := time.Unix(epochNanoToFormat/1000000000, 0)
 	timeInTimeZone := unixTime.In(loc)
 	l.PushString(timeInTimeZone.Format(layout))
 

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -32,7 +32,7 @@ func format(l *lua.State) int {
 		lua.Errorf(l, err.Error())
 	}
 
-	unixTime := time.Unix(epochNanoToFormat/1000000000, 0)
+	unixTime := time.Unix(epochNanoToFormat/1e9, 0)
 	timeInTimeZone := unixTime.In(loc)
 	l.PushString(timeInTimeZone.Format(layout))
 


### PR DESCRIPTION
Description: 
In the format function for time, the implementation is updated to convert the epoch nano while getting the unix time