### PR TITLE
Setup ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+      - run: go build
+      - run: go test ./...


### PR DESCRIPTION
We have a test suite for this application that's only run locally in development. We should be running these regularly via CI to ensure that no regressions are introduced into the project. I chose GitHub actions for this since it's used by various other open source repos across Shopify.