### PR TITLE
Add time parsing functions

### DIFF
--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,9 +1,12 @@
 package time
 
 import (
-	"github.com/Shopify/go-lua"
 	"time"
+
+	"github.com/Shopify/go-lua"
 )
+
+const ISO8601_FORMAT = `2006-01-02T15:04:05-07:00`
 
 func Open(l *lua.State) {
 	timeOpen := func(l *lua.State) int {
@@ -20,6 +23,8 @@ var timeLibrary = []lua.RegistryFunction{
 	{"sleep", sleep},
 	{"since", since},
 	{"add", add},
+	{"parse", parse},
+	{"parseISO", parseISO},
 }
 
 func format(l *lua.State) int {
@@ -72,5 +77,30 @@ func since(l *lua.State) int {
 	start := lua.CheckNumber(l, 1)
 	diff := float64(time.Now().UnixNano()) - start
 	l.PushNumber(diff)
+	return 1
+}
+
+func parse(l *lua.State) int {
+	format := lua.CheckString(l, 1)
+	value := lua.CheckString(l, 2)
+
+	return parseTime(l, format, value)
+}
+
+func parseISO(l *lua.State) int {
+	value := lua.CheckString(l, 1)
+
+	return parseTime(l, ISO8601_FORMAT, value)
+}
+
+func parseTime(l *lua.State, format, value string) int {
+	t, err := time.Parse(format, value)
+
+	if err != nil {
+		lua.Errorf(l, err.Error())
+	}
+
+	l.PushNumber(float64(t.UnixNano()))
+
 	return 1
 }

--- a/tst/time/time_test.lua
+++ b/tst/time/time_test.lua
@@ -22,3 +22,7 @@ local oneHrAdded = time.add(now, {hour= 1})
 local formattedTimeAhead = time.format(oneHrAdded, "2006-01-02T15:04:05Z", "")
 equals("time: added should be equal", 1.2578976e+18, oneHrAdded)
 equals("time format should be equal", "2009-11-11T00:00:00Z", formattedTimeAhead)
+
+
+equals("time: parse parses a time in a sepcified format", 1.257894e+18, time.parse("2006-01-02T15:04:05Z", "2009-11-10T23:00:00Z"))
+equals("time: parseISO parses a time string in ISO8601 encoding", 1.624030596e+18, time.parseISO("2021-06-18T11:36:36-04:00"))


### PR DESCRIPTION
There is currently no easy way to parse time strings in `genghis-flows`, and this seemed like the right place to add it. This function adds to functions to do so:
- `time.parse` which parses a time string using a provided format
- `time.parseISO` which parses a time string using the `ISO8601` format