### PR TITLE
Add md5 sum

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ name: goluago
 
 up:
   - go:
-      version: "1.16.2"
+      version: 1.18.4
       modules: true
 
 commands:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/goluago
 
-go 1.16
+go 1.18
 
 require (
 	github.com/Shopify/go-lua v0.0.0-20170207013001-67c3ba03ce82

--- a/pkg/crypto/md5/md5.go
+++ b/pkg/crypto/md5/md5.go
@@ -1,0 +1,28 @@
+package md5
+
+import (
+	"crypto/md5"
+	"fmt"
+
+	"github.com/Shopify/go-lua"
+)
+
+func Open(l *lua.State) {
+	md5Open := func(l *lua.State) int {
+		lua.NewLibrary(l, md5Library)
+		return 1
+	}
+	lua.Require(l, "goluago/encoding/md5", md5Open, false)
+	l.Pop(1)
+}
+
+var md5Library = []lua.RegistryFunction{
+	{"sum", sum},
+}
+
+func sum(l *lua.State) int {
+	data := lua.CheckString(l, 1)
+	sum := md5.Sum([]byte(data))
+	l.PushString(fmt.Sprintf("%x", sum))
+	return 1
+}

--- a/tst/crypto/md5/md5_test.lua
+++ b/tst/crypto/md5/md5_test.lua
@@ -1,0 +1,7 @@
+local sha256 = require("goluago/crypto/md5")
+
+equals(
+  "go-lua-go md5 string",
+  "b0dec8aeb0ab1bef807bb7fa5bde5792",
+  md5.sum(b0dec8aeb0ab1bef807bb7fa5bde5792)
+)


### PR DESCRIPTION
This PR adds the ability to do md5 sums in lua. It's pretty straight forward.

Usage:
```
sum = md5.sum("My String")
```