### PR TITLE
Add the ability to indent JSON

### DIFF
--- a/pkg/encoding/json/json.go
+++ b/pkg/encoding/json/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/Shopify/go-lua"
 	"github.com/Shopify/goluago/util"
@@ -31,11 +32,21 @@ func check(l *lua.State, err error) {
 func marshal(l *lua.State) int {
 	var t interface{}
 	var err error
+	var b []byte
+
 	if !l.IsNil(1) {
 		t, err = util.PullTable(l, 1)
 		check(l, err)
 	}
-	b, err := json.Marshal(t)
+
+	indent := lua.OptInteger(l, 2, 0)
+
+	if indent == 0 {
+		b, err = json.Marshal(t)
+	} else {
+		b, err = json.MarshalIndent(t, "", strings.Repeat(" ", indent))
+	}
+
 	check(l, err)
 	l.PushString(string(b))
 	return 1

--- a/tst/encoding/json/json_test.lua
+++ b/tst/encoding/json/json_test.lua
@@ -61,6 +61,17 @@ equals("unmarshal: can decode real use case JSON", want, got)
 istrue("unmarshal: true values should be true", got.complete)
 equals("marshal: can roundtrip real use case JSON", want, json.unmarshal(json.marshal(got)))
 
+-- Test indented output
+local input = {foo = 1 }
+local expected_output = [[{
+  "foo": 1
+}]]
+
+local actual_output = json.marshal(input, 2)
+
+equals("marshal: can encode indented JSON", expected_output, actual_output)
+
+
 -- Error case
 local trailingComma = [=[
 {


### PR DESCRIPTION
While working on Lua documentation noticed a lack of parity between the TS JSON library and the Lua one. We use prettified JSON as a way to show output [here](https://github.com/Shopify/cronograma/blob/enhanced-docs/docusaurus/docs/flows/reference/typescript/http.md) and I'd like to be able to do the same for Lua.