### PR TITLE
Fix broken implementation of MD5

### DIFF
--- a/goluago.go
+++ b/goluago.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Shopify/go-lua"
 	"github.com/Shopify/goluago/pkg/crypto/aes"
 	"github.com/Shopify/goluago/pkg/crypto/hmac"
+	"github.com/Shopify/goluago/pkg/crypto/md5"
 	"github.com/Shopify/goluago/pkg/crypto/sha256"
 	"github.com/Shopify/goluago/pkg/encoding/base64"
 	"github.com/Shopify/goluago/pkg/encoding/hex"
@@ -33,4 +34,5 @@ func Open(l *lua.State) {
 	hex.Open(l)
 	sha256.Open(l)
 	aes.Open(l)
+	md5.Open(l)
 }

--- a/pkg/crypto/md5/md5.go
+++ b/pkg/crypto/md5/md5.go
@@ -12,7 +12,7 @@ func Open(l *lua.State) {
 		lua.NewLibrary(l, md5Library)
 		return 1
 	}
-	lua.Require(l, "goluago/encoding/md5", md5Open, false)
+	lua.Require(l, "goluago/crypto/md5", md5Open, false)
 	l.Pop(1)
 }
 

--- a/tst/crypto/md5/md5_test.lua
+++ b/tst/crypto/md5/md5_test.lua
@@ -1,7 +1,7 @@
-local sha256 = require("goluago/crypto/md5")
+local md5 = require("goluago/crypto/md5")
 
 equals(
   "go-lua-go md5 string",
-  "b0dec8aeb0ab1bef807bb7fa5bde5792",
-  md5.sum(b0dec8aeb0ab1bef807bb7fa5bde5792)
+  "b0804ec967f48520697662a204f5fe72",
+  md5.sum("These pretzels are making me thirsty.")
 )

--- a/tst/lua_test.go
+++ b/tst/lua_test.go
@@ -1,8 +1,9 @@
 package tst
 
 import (
-	"github.com/Shopify/goluago"
 	"testing"
+
+	"github.com/Shopify/goluago"
 )
 
 var tests = []struct {
@@ -22,6 +23,7 @@ var tests = []struct {
 	{"hex", "encoding/hex/hex_test.lua"},
 	{"sha256", "crypto/sha256/sha256_test.lua"},
 	{"aes", "crypto/aes/aes_test.lua"},
+	{"md5", "crypto/md5/md5_test.lua"},
 }
 
 func TestAllPackages(t *testing.T) {


### PR DESCRIPTION
While working on https://github.com/Shopify/cronograma/issues/3308 I found out that `md5` was not actually supported in `goluago`. The following issues were present:
- The library was listed under `encoding` and not `crypto`
- The library was not actually being exported from the `goluago` package
- The unit tests for this library were not actually being run (and contained Lua syntax errors)

All of these issues have now been fixed and MD5 should be 👌 now for the Lua runtime.