### PR TITLE
Update version of Golang to 1.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.22.1
       - run: go build
       - run: go test ./...

--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ name: goluago
 
 up:
   - go:
-      version: 1.19.1
+      version: 1.22.1
       modules: true
 
 commands:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/goluago
 
-go 1.19
+go 1.22
 
 require (
 	github.com/Shopify/go-lua v0.0.0-20170207013001-67c3ba03ce82


### PR DESCRIPTION
Updates Golang to 1.22.1 to use a version that includes several security fixes: https://go.dev/doc/devel/release#go1.22.1